### PR TITLE
🪓 Feat: branch switching condition

### DIFF
--- a/internal/application/commands/checkout.go
+++ b/internal/application/commands/checkout.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/UtkarshM-hub/Lit/internal/application/core"
 	util "github.com/UtkarshM-hub/Lit/internal/application/core/util"
+	color "github.com/gookit/color"
 	"github.com/spf13/cobra"
 )
 
@@ -38,6 +39,19 @@ var checkoutCmd = &cobra.Command{
 		err = util.DoesExists(branch_refFile_Path)
 		if err != nil {
 			fmt.Printf("Branch with name '%v' doesn't exist\n", branchName)
+			return
+		}
+
+		// prevent user from switching branch if current branch containers changes to be stages
+		indexFilePath := filepath.Join(dir, "./.lit/index")
+
+		files := core.GetFilesStatus(dir)
+
+		tracked, untracked, modified, deleted, err := core.GetStatus(files, indexFilePath)
+
+		if len(tracked) != 0 || len(untracked) != 0 || len(modified) != 0 || len(deleted) != 0 {
+			fmt.Println("On branch <branch_name>")
+			color.Red.Println("Commit changes before switching to another branch")
 			return
 		}
 


### PR DESCRIPTION
Fixes #15 
### Changes Implemented
- Branch switching can only be done if there are no changes to be committed in current branch