### PR TITLE
📄 Refactor: Remove unnecessary prints and rename the main package directory

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,9 +1,0 @@
-package main
-
-import (
-	cmd "github.com/UtkarshM-hub/bit/internal/application/commands"
-)
-
-func main() {
-	cmd.Execute()
-}

--- a/internal/application/commands/init.go
+++ b/internal/application/commands/init.go
@@ -3,7 +3,6 @@ package commands
 import (
 	"fmt"
 	"path/filepath"
-	"time"
 
 	core "github.com/UtkarshM-hub/bit/internal/application/core"
 	util "github.com/UtkarshM-hub/bit/internal/application/core/util"
@@ -19,8 +18,6 @@ var initCmd = &cobra.Command{
 	Short: "Initializes current directory as bit directory",
 	Long:  `Initializes current directory as bit directory`,
 	Run: func(cmd *cobra.Command, args []string) {
-
-		t := time.Now()
 		var dir string
 		var err error
 
@@ -63,6 +60,5 @@ var initCmd = &cobra.Command{
 		if done {
 			fmt.Println(args[0], "initialized as bit directory")
 		}
-		fmt.Println(dir, done, time.Since(t))
 	},
 }

--- a/internal/application/core/add.go
+++ b/internal/application/core/add.go
@@ -96,7 +96,7 @@ func createNewObject(status string, newmp *map[string]FileInfo, files []FileInfo
 	}
 }
 
-// takes current file information from status command and writes it to the index file 
+// takes current file information from status command and writes it to the index file
 // resulting into moving those files into staging area
 // takes root directory filepath and fileinfo
 func CoreAdd(path string, untracked, modified, deleted []FileInfo) {
@@ -130,7 +130,6 @@ func writeToIndex(mp map[string]FileInfo, path string) {
 
 	var rawData []string
 	for _, v := range mp {
-		fmt.Println(v.FilePath)
 		line := fmt.Sprintf("%v %v %v %v %v %v %v %v", v.FileName, v.FileModifiedAt, v.FileSize, v.FilePerm, v.SHA1, strings.Replace(v.FilePath, " ", "||", -1), v.FileStatus, v.CommitStatus)
 
 		// fmt.Printf("Name: %v\nPath: %v\nTime: %v\nPerm: %v\nSize: %v\nSHA1: %v\n\n", v.FileName, strings.Replace(v.FilePath," ","||",-1), v.FileModifiedAt, v.FilePerm, v.FileSize,v.SHA1)

--- a/internal/application/core/branch.go
+++ b/internal/application/core/branch.go
@@ -104,7 +104,6 @@ func Checkout(PathToLit, BranchName string) {
 	// Change only the necessary info if the branch is new
 	// No need to perform deletion and all
 	if len(commit_hash) == 0 {
-		fmt.Println("empty")
 		// change active branch
 		err = ChangeActiveBranch(PathToLit, BranchName)
 		if err != nil {
@@ -134,7 +133,7 @@ func Checkout(PathToLit, BranchName string) {
 
 	// Write the new index file content to index file
 	writeToIndex(New_Branch_Index, index_file_path)
-	
+
 	// write the new index file content to past file
 	writeToIndex(New_Branch_Index, past_file_path)
 
@@ -145,6 +144,8 @@ func Checkout(PathToLit, BranchName string) {
 	if err != nil {
 		fmt.Println(err)
 	}
+
+	fmt.Println("Switched to branch", BranchName)
 
 	// // After switching branches remove these ghost directories which contains no files
 	// DeleteEmptyDir(PathToLit)
@@ -275,24 +276,20 @@ func GenerateIndex(PathToLit, Tree_Object_Hash string) (map[string]FileInfo, err
 
 // Performs actual switching operation of branch command
 func Switch(dir string, currentB, newB map[string]FileInfo) error {
-	fmt.Println("switch start")
 
 	// Loop over new Branch
 	for _, v := range newB {
 		fileInfo, exists := currentB[v.FilePath]
-		fmt.Println("switch mid", v.FilePath)
 
 		if exists {
 			delete(currentB, v.FilePath)
 			// skip if file already exists and hash value is same
 			if fileInfo.SHA1 == v.SHA1 {
-				fmt.Println("switch cont", v.FilePath)
 				delete(newB, v.FilePath)
 				continue
 			} else {
 				// delete the existing file and new file will be created in the following code
 				err := os.Remove(fileInfo.FilePath)
-				fmt.Println("switch rm", v.FilePath)
 				if err != nil {
 					fmt.Println(err.Error())
 					return err
@@ -310,18 +307,14 @@ func Switch(dir string, currentB, newB map[string]FileInfo) error {
 			}
 		}
 
-		fmt.Println("switch creating", v.FilePath)
-
 		// Now as we have our directory structure for the current file setup
 		// we can proceed to create the file by decompressing it and storing it at a particular location
 		inputFilePath := filepath.Join(dir, "/.bit/objects", string(v.SHA1[:2])+"/"+string(v.SHA1[2:]))
 
-		fmt.Println(inputFilePath, v.FilePath)
-
 		err = DecompressAndSaveFile(inputFilePath, v.FilePath)
 
 		if err != nil {
-			fmt.Println("this is it", err.Error())
+			fmt.Println(err.Error())
 		}
 		delete(newB, v.FilePath)
 	}

--- a/internal/application/core/commit.go
+++ b/internal/application/core/commit.go
@@ -202,9 +202,6 @@ func createTreeObj(dirContent []TreeInfo, path, dirName string) (TreeInfo, error
 		fileContent = append(fileContent, line)
 	}
 	content := strings.Join(fileContent, "\n")
-	fmt.Println(dirName)
-	fmt.Println(content)
-	fmt.Println("--------------------------------------------")
 
 	// find SHA1
 	header := "tree" + " " + directoryName + "\\0"


### PR DESCRIPTION
## Changes made:

- renamed the `cmd` directory to `bit` so that after running `go install` it will install as bit and not cmd
- removed unnecessary print statements which were used for debugging purposes while development